### PR TITLE
✨ Add terraform-docs pre-commit hook (closes #237)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,13 @@ repos:
       - id: terraform-validate
       - id: shellcheck
 
+  - repo: https://github.com/terraform-docs/terraform-docs
+    rev: v0.24.0
+    hooks:
+      - id: terraform-docs-go
+        args:
+          ["markdown", "table", "--output-file", "README.md", "--output-mode", "inject", "."]
+
   - repo: https://github.com/mxab/pre-commit-trivy.git
     rev: v0.9.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,9 +14,19 @@ repos:
   - repo: https://github.com/terraform-docs/terraform-docs
     rev: v0.24.0
     hooks:
+      # -go variant matches the existing gruntwork golang-based hooks above; contributors
+      # already need Go on $PATH for terratest. Switch to -system or -docker if that changes.
       - id: terraform-docs-go
         args:
-          ["markdown", "table", "--output-file", "README.md", "--output-mode", "inject", "."]
+          [
+            "markdown",
+            "table",
+            "--output-file",
+            "README.md",
+            "--output-mode",
+            "inject",
+            ".",
+          ]
 
   - repo: https://github.com/mxab/pre-commit-trivy.git
     rev: v0.9.0


### PR DESCRIPTION
## Summary

Adds the upstream `terraform-docs-go` hook to `.pre-commit-config.yaml` so the README inputs/outputs tables regenerate on every commit that touches `variables.tf` / `outputs.tf`. Closes the silent-drift gap identified during review of #204, where the variable-shape change shipped without a README regen and the docs lied to readers until someone ran `terraform-docs` by hand.

## Changes

- `.pre-commit-config.yaml`: new hook block, pinned to `v0.24.0` (current upstream latest), ordered **before** `prettier` so prettier reformats the regenerated table to the project's markdown style.

## Notes

- No README diff in this commit — the table was just regenerated as part of #204's merge (`f936cbc`), so the hook here is purely forward-protection. Subsequent variable changes will trigger the regen automatically on local commit.
- CI doesn't currently run pre-commit (it runs individual linters via reviewdog), so this hook enforces only on contributors with `pre-commit install`. That matches the existing pattern in this file. If you want CI-side enforcement too, that's a separate follow-up (`terraform-docs/gh-actions` in a workflow + dirty-check).
- This is **stage 1** of a sweep — once this merges, the same hook will be mirrored across the other `bendoerr-terraform-modules/*` module repos. (Ben approved scope; tracked in `code-kitten/state/checkpoint.md`.)

Closes #237.

---

🤖 Generated by code-kitten on behalf of @bendoerr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit configuration to include Terraform documentation generation tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->